### PR TITLE
Fix casing in GitHub reference in footer

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -74,7 +74,7 @@
 				<svg role="presentation" aria-hidden="true"><use xlink:href="#monogram"></use></svg>
 				<span class="is-hidden">localtunnel</span>
 			</a>
-			<a class="footer__github-link c-white" href="//github.com/localtunnel/localtunnel"><strong>View the project on Github</strong></a>
+			<a class="footer__github-link c-white" href="//github.com/localtunnel/localtunnel"><strong>View the project on GitHub</strong></a>
 		</div>
 	</footer>
 


### PR DESCRIPTION
I was poking around looking for something in the documentation and noticed that GitHub is spelled Github in the footer. This is a very minor nitpick.

Per the logos that GitHub provides, the H should be upper-case.

See https://github.com/logos

🌷 
